### PR TITLE
Add config option for battery power display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -8,7 +8,8 @@ import {
     SOC_THRESH_MED_COLOUR,
     SOC_THRESH_V_HIGH,
     SOC_THRESH_V_HIGH_COLOUR,
-    SOC_THRESH_V_LOW_COLOUR
+    SOC_THRESH_V_LOW_COLOUR,
+    DISPLAY_ABS_POWER
 } from "./constants";
 
 export class ConfigUtils {
@@ -25,6 +26,7 @@ export class ConfigUtils {
             soc_threshold_medium_colour: SOC_THRESH_MED_COLOUR,
             soc_threshold_low_colour: SOC_THRESH_LOW_COLOUR,
             soc_threshold_very_low_colour: SOC_THRESH_V_LOW_COLOUR,
+            display_abs_power: DISPLAY_ABS_POWER,
         };
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,5 @@ export const SOC_THRESH_MED_COLOUR = [255, 166, 0]; //#ffa600
 export const SOC_THRESH_LOW = 20;
 export const SOC_THRESH_LOW_COLOUR = [219, 68, 55]; //#db4437
 export const SOC_THRESH_V_LOW_COLOUR = [94, 0, 0]; //#5e0000
+
+export const DISPLAY_ABS_POWER = false;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -123,6 +123,14 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                     color_rgb: {}
                 }
             },
+            {
+                name: 'display_abs_power',
+                label: 'Display power usage as absolute value',
+                default: defaults.display_abs_power,
+                selector: {
+                    boolean: {}
+                }
+            }
         ];
     }
 

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -10,6 +10,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { HassEntity } from 'home-assistant-js-websocket';
 
 import {
+  DISPLAY_ABS_POWER,
   SOC_THRESH_HIGH,
   SOC_THRESH_HIGH_COLOUR,
   SOC_THRESH_LOW,
@@ -195,6 +196,10 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
     statsList.push(timeLeft);
 
+    const displayAbsPower = (this.config.display_abs_power !== undefined) ? this.config.display_abs_power : DISPLAY_ABS_POWER;
+
+    const p = (displayAbsPower) ? Math.abs(power) : power;
+
     const powerUse = html`
       <div 
           class="stats-block" 
@@ -202,7 +207,7 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
           id="gtpc-battery-detail-battery-power"
       >
         <span class="stats-value ${powerColourClass}">
-          ${Math.abs(power)} 
+          ${p} 
         </span>
         Wh
         <div class="stats-subtitle">${powerSubtitle}</div>


### PR DESCRIPTION
Adds a configuration option to toggle whether battery power is displayed as an absolute value, or +/- depending on out/in power