### PR TITLE
Pre-calculate battery stats based on GivTCP UoM attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.1.2",
+  "version": "0.1.9",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,64 @@
+
+export interface GivTcpBatteryStats {
+    socPercent: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        value: number,
+        display: number,
+        displayStr: string,
+    },
+    batteryPower: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        w: number,
+        kW: number,
+        display: number,
+        displayStr: string,
+        displayUnit: string,
+    },
+    socEnergy: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        Wh: number,
+        kWh: number,
+        display: number,
+        displayStr: string,
+    },
+    dischargePower: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        w: number,
+        kW: number,
+        display: number,
+        displayStr: string,
+    },
+    chargePower: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        w: number,
+        kW: number,
+        display: number,
+        displayStr: string,
+    },
+    batteryCapacity: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        Wh: number,
+        kWh: number,
+        display: number,
+        displayStr: string,
+    },
+    batteryPowerReservePercent: {
+        rawState: string, // store raw value from GivTCP
+        uom: string | undefined, // unit_of_measurement form GivTCP
+        value: number,
+        display: number,
+        displayStr: string,
+    },
+    batteryPowerReserveEnergy: {
+        Wh: number,
+        kWh: number,
+        display: number,
+        displayStr: string,
+    },
+}


### PR DESCRIPTION
Resolves #21 - the card did not previously take into account the configurable `unit_of_measurement` attribute available in the GivTCP entities. This PR fixes the issue, in addition to refactoring the code to pre-calculate all statistics during render time in a single object. Thanks to @gcoan for reporting the issue.

- Add `GivTcpBatteryStats` type
- Add `setRawValues` method to grab GivTCP data at render time
- Pre-calculate battery stats based on raw values and GivTCP's `unit_of_measurement` value if available
