### PR TITLE
Feature - Experimental DoD override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.1.9",
+  "version": "0.2.0-beta",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.2.0-beta",
+  "version": "0.2.0-beta.2",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -16,7 +16,10 @@ import {
     ICON_STATUS_IDLE,
     ICON_STATUS_CHARGING,
     ICON_STATUS_DISCHARGING,
-    DISPLAY_BATTERY_RATES, USE_CUSTOM_DOD, CUSTOM_DOD,
+    DISPLAY_BATTERY_RATES,
+    USE_CUSTOM_DOD,
+    CUSTOM_DOD,
+    CALCULATE_RESERVE_FROM_DOD,
 } from "./constants";
 
 export class ConfigUtils {
@@ -42,6 +45,7 @@ export class ConfigUtils {
             display_battery_rates: DISPLAY_BATTERY_RATES,
             use_custom_dod: USE_CUSTOM_DOD,
             custom_dod: CUSTOM_DOD,
+            calculate_reserve_from_dod: CALCULATE_RESERVE_FROM_DOD,
         };
     }
 

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -16,7 +16,7 @@ import {
     ICON_STATUS_IDLE,
     ICON_STATUS_CHARGING,
     ICON_STATUS_DISCHARGING,
-    DISPLAY_BATTERY_RATES,
+    DISPLAY_BATTERY_RATES, USE_CUSTOM_DOD, CUSTOM_DOD,
 } from "./constants";
 
 export class ConfigUtils {
@@ -40,6 +40,8 @@ export class ConfigUtils {
             icon_status_charging: ICON_STATUS_CHARGING,
             icon_status_discharging: ICON_STATUS_DISCHARGING,
             display_battery_rates: DISPLAY_BATTERY_RATES,
+            use_custom_dod: USE_CUSTOM_DOD,
+            custom_dod: CUSTOM_DOD,
         };
     }
 

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -19,7 +19,7 @@ import {
     DISPLAY_BATTERY_RATES,
     USE_CUSTOM_DOD,
     CUSTOM_DOD,
-    CALCULATE_RESERVE_FROM_DOD,
+    CALCULATE_RESERVE_FROM_DOD, DISPLAY_CUSTOM_DOD_STATS,
 } from "./constants";
 
 export class ConfigUtils {
@@ -46,6 +46,7 @@ export class ConfigUtils {
             use_custom_dod: USE_CUSTOM_DOD,
             custom_dod: CUSTOM_DOD,
             calculate_reserve_from_dod: CALCULATE_RESERVE_FROM_DOD,
+            display_custom_dod_stats: DISPLAY_CUSTOM_DOD_STATS,
         };
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,3 +24,7 @@ export const ICON_STATUS_CHARGING = 'mdi:lightning-bolt';
 export const ICON_STATUS_DISCHARGING = 'mdi:home-battery';
 
 export const DISPLAY_BATTERY_RATES = true;
+
+export const USE_CUSTOM_DOD = false;
+
+export const CUSTOM_DOD = 100.0;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,3 +30,5 @@ export const USE_CUSTOM_DOD = false;
 export const CUSTOM_DOD = 100.0;
 
 export const CALCULATE_RESERVE_FROM_DOD = false;
+
+export const DISPLAY_CUSTOM_DOD_STATS = true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,3 +32,10 @@ export const CUSTOM_DOD = 100.0;
 export const CALCULATE_RESERVE_FROM_DOD = false;
 
 export const DISPLAY_CUSTOM_DOD_STATS = true;
+
+export const DISPLAY_UNITS = {
+    W: "W",
+    KW: "kW",
+    WH: "Wh",
+    KWH: "kWh",
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,3 +28,5 @@ export const DISPLAY_BATTERY_RATES = true;
 export const USE_CUSTOM_DOD = false;
 
 export const CUSTOM_DOD = 100.0;
+
+export const CALCULATE_RESERVE_FROM_DOD = false;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -198,6 +198,14 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 }
             },
             {
+                name: 'display_custom_dod_stats',
+                label: 'EXPERIMENTAL! Display the custom DOD stats',
+                default: defaults.display_custom_dod_stats,
+                selector: {
+                    boolean: {}
+                }
+            },
+            {
                 name: 'custom_dod',
                 label: 'EXPERIMENTAL! Custom DoD as percentage to override GivTCP battery capacity value.',
                 default: defaults.custom_dod,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -210,6 +210,14 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                     }
                 }
             },
+            {
+                name: 'calculate_reserve_from_dod',
+                label: 'EXPERIMENTAL! Use custom DoD to calculate the battery reserve value',
+                default: defaults.calculate_reserve_from_dod,
+                selector: {
+                    boolean: {}
+                }
+            },
         ];
     }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -137,7 +137,7 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
             },
             {
                 name: 'display_type',
-                label: 'Display type (0: Wh | 1: kWh | 2: Dynamic)',
+                label: 'Display type (0: Wh/W | 1: kWh/kW | 2: Dynamic)',
                 default: defaults.display_type,
                 selector: {
                     number: {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -46,7 +46,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 selector: {
                     number: {
                         min: 0,
-                        max: 100
+                        max: 100,
+                        unit_of_measurement: "%",
                     }
                 }
             },
@@ -65,7 +66,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 selector: {
                     number: {
                         min: 0,
-                        max: 100
+                        max: 100,
+                        unit_of_measurement: "%",
                     }
                 }
             },
@@ -84,7 +86,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 selector: {
                     number: {
                         min: 0,
-                        max: 100
+                        max: 100,
+                        unit_of_measurement: "%",
                     }
                 }
             },
@@ -103,7 +106,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 selector: {
                     number: {
                         min: 0,
-                        max: 100
+                        max: 100,
+                        unit_of_measurement: "%",
                     }
                 }
             },
@@ -183,6 +187,27 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 default: defaults.display_battery_rates,
                 selector: {
                     boolean: {}
+                }
+            },
+            {
+                name: 'use_custom_dod',
+                label: 'EXPERIMENTAL! Use custom DoD to override GivTCP battery capacity value.',
+                default: defaults.use_custom_dod,
+                selector: {
+                    boolean: {}
+                }
+            },
+            {
+                name: 'custom_dod',
+                label: 'EXPERIMENTAL! Custom DoD as percentage to override GivTCP battery capacity value.',
+                default: defaults.custom_dod,
+                selector: {
+                    number: {
+                        min: 0,
+                        max: 100,
+                        step: "any",
+                        unit_of_measurement: "%",
+                    }
                 }
             },
         ];

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -503,17 +503,19 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
     const customDod = (this.config.custom_dod !== undefined) ? this.config.custom_dod : CUSTOM_DOD;
 
     let dod = html``;
+    let capacityPrefix = "";
     if(useCustomDod) {
+      capacityPrefix = "Usable"
       dod = html`
         <div class="status">
-          <span class="status-text-small"> DoD: ${customDod}% | Usable Capacity: ${this.calculatedStates.usableBatteryCapacity.displayStr}</span>
+          <span class="status-text-small"> DoD: ${customDod}% | Actual Capacity: ${this.calculatedStates.batteryCapacity.displayStr}</span>
         </div>`
     }
 
     return html`
       <div>
         <div class="status">
-          <span class="status-text"> Capacity: ${this.calculatedStates.batteryCapacity.displayStr} | Reserve: ${this.calculatedStates.batteryPowerReserveEnergy.displayStr} (${this.calculatedStates.batteryPowerReservePercent.displayStr})</span>
+          <span class="status-text"> ${capacityPrefix} Capacity: ${this.calculatedStates.usableBatteryCapacity.displayStr} | Reserve: ${this.calculatedStates.batteryPowerReserveEnergy.displayStr} (${this.calculatedStates.batteryPowerReservePercent.displayStr})</span>
         </div>
         ${dod}
       </div>

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -442,7 +442,7 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
       states.usableBatteryCapacity.kWh = usableKwh;
 
       const socWh = Math.round(usableWh * soc);
-      const socKwh = this.convertToKillo(socWh, dp);
+      const socKwh = this.convertToKillo(socWh, 3);
       states.calculatedSocEnergy.Wh = socWh;
       states.calculatedSocEnergy.kWh = socKwh;
 
@@ -471,19 +471,19 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
         case DISPLAY_TYPE_OPTIONS.KWH:
           states.usableBatteryCapacity.display = usableKwh;
           states.usableBatteryCapacity.displayStr = `${usableKwh} kWh`;
-          states.calculatedSocEnergy.display = socKwh;
-          states.calculatedSocEnergy.displayStr = `${socKwh} kWh`;
+          states.calculatedSocEnergy.display = this.convertToKillo(socWh, dp);
+          states.calculatedSocEnergy.displayStr = `${this.convertToKillo(socWh, dp)} kWh`;
           if(reserveFromDod) {
-            states.batteryPowerReserveEnergy.display = usableBatteryPowerReserveEnergyKWh;
-            states.batteryPowerReserveEnergy.displayStr = `${usableBatteryPowerReserveEnergyKWh} Wh`;
+            states.batteryPowerReserveEnergy.display = this.convertToKillo(usableBatteryPowerReserveEnergyWh, dp);
+            states.batteryPowerReserveEnergy.displayStr = `${this.convertToKillo(usableBatteryPowerReserveEnergyWh, dp)} kWh`;
           }
           break;
         case DISPLAY_TYPE_OPTIONS.DYNAMIC:
           states.usableBatteryCapacity.display = (Math.abs(usableWh) >= 1000) ? usableKwh : usableWh;
           states.usableBatteryCapacity.displayStr = (Math.abs(usableWh) >= 1000) ? `${usableKwh} kWh` : `${usableWh} Wh`;
 
-          states.calculatedSocEnergy.display = (Math.abs(socWh) >= 1000) ? socKwh : socWh;
-          states.calculatedSocEnergy.displayStr = (Math.abs(socWh) >= 1000) ? `${socKwh} kWh` : `${socWh} Wh`;
+          states.calculatedSocEnergy.display = (Math.abs(socWh) >= 1000) ? this.convertToKillo(socWh, dp) : socWh;
+          states.calculatedSocEnergy.displayStr = (Math.abs(socWh) >= 1000) ? `${this.convertToKillo(socWh, dp)} kWh` : `${socWh} Wh`;
 
           if(reserveFromDod) {
             states.batteryPowerReserveEnergy.display = (Math.abs(usableBatteryPowerReserveEnergyWh) >= 1000) ? this.convertToKillo(usableBatteryPowerReserveEnergyWh, dp) : usableBatteryPowerReserveEnergyWh;

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -25,7 +25,9 @@ import {
   SOC_THRESH_V_LOW_COLOUR,
   DISPLAY_BATTERY_RATES,
   USE_CUSTOM_DOD,
-  CUSTOM_DOD, CALCULATE_RESERVE_FROM_DOD,
+  CUSTOM_DOD,
+  CALCULATE_RESERVE_FROM_DOD,
+  DISPLAY_CUSTOM_DOD_STATS,
 } from "./constants";
 
 import './components/countdown'
@@ -501,10 +503,11 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
     const useCustomDod = (this.config.use_custom_dod !== undefined) ? this.config.use_custom_dod : USE_CUSTOM_DOD;
     const customDod = (this.config.custom_dod !== undefined) ? this.config.custom_dod : CUSTOM_DOD;
+    const displayCustomDod = (this.config.display_custom_dod_stats !== undefined) ? this.config.display_custom_dod_stats : DISPLAY_CUSTOM_DOD_STATS;
 
     let dod = html``;
     let capacityPrefix = "";
-    if(useCustomDod) {
+    if(useCustomDod && displayCustomDod) {
       capacityPrefix = "Usable"
       dod = html`
         <div class="status">

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -381,16 +381,16 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
         states.dischargeRate.displayStr = `${dischargeRateW} W`;
         break;
       case DISPLAY_TYPE_OPTIONS.KWH:
-        states.batteryCapacity.display = batteryCapacityKwh;
-        states.batteryCapacity.displayStr = `${batteryCapacityKwh} kWh`;
+        states.batteryCapacity.display = this.convertToKillo(batteryCapacityWh, dp);
+        states.batteryCapacity.displayStr = `${this.convertToKillo(batteryCapacityWh, dp)} kWh`;
         states.batteryPower.display = (displayAbsPower) ? this.convertToKillo(Math.abs(batteryPowerW), dp) : this.convertToKillo(batteryPowerW, dp);
         states.batteryPower.displayStr = `${(displayAbsPower) ? this.convertToKillo(Math.abs(batteryPowerW), dp) : this.convertToKillo(batteryPowerW, dp)} kW`;
         states.chargePower.display = this.convertToKillo(chargePowerW, dp);
         states.chargePower.displayStr = `${this.convertToKillo(chargePowerW, dp)} kW`;
         states.dischargePower.display = this.convertToKillo(dischargePowerW, dp);
         states.dischargePower.displayStr = `${this.convertToKillo(dischargePowerW, dp)} kW`;
-        states.socEnergy.display = socEnergyKWh;
-        states.socEnergy.displayStr = `${socEnergyKWh} kWh`;
+        states.socEnergy.display = this.convertToKillo(socEnergyWh, dp);
+        states.socEnergy.displayStr = `${this.convertToKillo(socEnergyWh, dp)} kWh`;
         states.batteryPowerReserveEnergy.display = this.convertToKillo(batteryPowerReserveEnergyWh, dp);
         states.batteryPowerReserveEnergy.displayStr = `${this.convertToKillo(batteryPowerReserveEnergyWh, dp)} kWh`;
         states.batteryPower.displayUnit = 'kW';
@@ -400,8 +400,8 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
         states.dischargeRate.displayStr = `${this.convertToKillo(dischargeRateW, dp)} kW`;
         break;
       case DISPLAY_TYPE_OPTIONS.DYNAMIC:
-        states.batteryCapacity.display = (Math.abs(batteryCapacityWh) >= 1000) ? batteryCapacityKwh : batteryCapacityWh;
-        states.batteryCapacity.displayStr = (Math.abs(batteryCapacityWh) >= 1000) ? `${batteryCapacityKwh} kWh` : `${batteryCapacityWh} Wh`;
+        states.batteryCapacity.display = (Math.abs(batteryCapacityWh) >= 1000) ? this.convertToKillo(batteryCapacityWh, dp)  : batteryCapacityWh;
+        states.batteryCapacity.displayStr = (Math.abs(batteryCapacityWh) >= 1000) ? `${this.convertToKillo(batteryCapacityWh, dp) } kWh` : `${batteryCapacityWh} Wh`;
 
         states.batteryPower.display = (Math.abs(batteryPowerW) >= 1000) ? ((displayAbsPower) ? this.convertToKillo(Math.abs(batteryPowerW), dp) : this.convertToKillo(batteryPowerW, dp)) : ((displayAbsPower) ? Math.abs(batteryPowerW) : batteryPowerW);
         states.batteryPower.displayStr = (Math.abs(batteryPowerW) >= 1000) ? `${(displayAbsPower) ? this.convertToKillo(Math.abs(batteryPowerW), dp) : this.convertToKillo(batteryPowerW, dp)} kW` : `${(displayAbsPower) ? Math.abs(batteryPowerW) : batteryPowerW} W`;
@@ -414,8 +414,8 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
         states.batteryPowerReserveEnergy.display = (Math.abs(batteryPowerReserveEnergyWh) >= 1000) ? this.convertToKillo(batteryPowerReserveEnergyWh, dp) : batteryPowerReserveEnergyWh;
         states.batteryPowerReserveEnergy.displayStr = (Math.abs(batteryPowerReserveEnergyWh) >= 1000) ? `${this.convertToKillo(batteryPowerReserveEnergyWh, dp)} kWh` : `${batteryPowerReserveEnergyWh} Wh`;
 
-        states.socEnergy.display = (Math.abs(socEnergyWh) >= 1000) ? socEnergyKWh : socEnergyWh;
-        states.socEnergy.displayStr = (Math.abs(socEnergyWh) >= 1000) ? `${socEnergyKWh} kWh` : `${socEnergyWh} Wh`;
+        states.socEnergy.display = (Math.abs(socEnergyWh) >= 1000) ? this.convertToKillo(socEnergyWh, dp) : socEnergyWh;
+        states.socEnergy.displayStr = (Math.abs(socEnergyWh) >= 1000) ? `${this.convertToKillo(socEnergyWh, dp)} kWh` : `${socEnergyWh} Wh`;
 
         states.chargeRate.display = (Math.abs(chargeRateW) >= 1000) ? this.convertToKillo(chargeRateW, dp) : chargeRateW;
         states.chargeRate.displayStr = (Math.abs(chargeRateW) >= 1000) ? `${this.convertToKillo(chargeRateW, dp)} kW` : `${chargeRateW} W`;

--- a/src/style.ts
+++ b/src/style.ts
@@ -186,83 +186,83 @@ export const styleCss = css`
     background-color: rgba(0,0,0,0);
   }
 
-  .progress-bar-fill-r0 {
+  .progress-bar-fill-r10 {
     background-color: #DB4437ff;
   }
 
-  .progress-bar-fill-r10 {
+  .progress-bar-fill-r20 {
     background-color: #CD3C31ff;
   }
 
-  .progress-bar-fill-r20 {
+  .progress-bar-fill-r30 {
     background-color: #BF352Bff;
   }
 
-  .progress-bar-fill-r30 {
+  .progress-bar-fill-r40 {
     background-color: #B12D25ff;
   }
 
-  .progress-bar-fill-r40 {
+  .progress-bar-fill-r50 {
     background-color: #A3261Fff;
   }
 
-  .progress-bar-fill-r50 {
+  .progress-bar-fill-r60 {
     background-color: #961E18ff;
   }
 
-  .progress-bar-fill-r60 {
+  .progress-bar-fill-r70 {
     background-color: #881712ff;
   }
 
-  .progress-bar-fill-r70 {
+  .progress-bar-fill-r80 {
     background-color: #7A0F0Cff;
   }
 
-  .progress-bar-fill-r80 {
+  .progress-bar-fill-r90 {
     background-color: #6C0806ff;
   }
 
-  .progress-bar-fill-r90 {
+  .progress-bar-fill-r100 {
     background-color: #5E0000ff;
   }
 
-  .progress-bar-fill-g0 {
+  .progress-bar-fill-g10 {
     background-color: #43A047ff;
   }
 
-  .progress-bar-fill-g10 {
+  .progress-bar-fill-g20 {
     background-color: #3C9642ff;
   }
 
-  .progress-bar-fill-g20 {
+  .progress-bar-fill-g30 {
     background-color: #348C3Cff;
   }
 
-  .progress-bar-fill-g30 {
+  .progress-bar-fill-g40 {
     background-color: #2D8237ff;
   }
 
-  .progress-bar-fill-g40 {
+  .progress-bar-fill-g50 {
     background-color: #257832ff;
   }
 
-  .progress-bar-fill-g50 {
+  .progress-bar-fill-g60 {
     background-color: #1E6D2Cff;
   }
 
-  .progress-bar-fill-g60 {
+  .progress-bar-fill-g70 {
     background-color: #166327ff;
   }
 
-  .progress-bar-fill-g70 {
+  .progress-bar-fill-g80 {
     background-color: #0F5922ff;
   }
 
-  .progress-bar-fill-g80 {
+  .progress-bar-fill-g90 {
     background-color: #074F1Cff;
   }
 
-  .progress-bar-fill-g90 {
+  .progress-bar-fill-g100 {
     background-color: #004517ff;
   }
 

--- a/src/style.ts
+++ b/src/style.ts
@@ -58,6 +58,10 @@ export const styleCss = css`
   }
 
   .status-text-small {
+    color: var(--vc-secondary-text-color);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
     font-size: 12px;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,14 @@
 export interface GivTcpBatteryStats {
     socPercent: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         value: number,
         display: number,
         displayStr: string,
     },
     batteryPower: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         w: number,
         kW: number,
         display: number,
@@ -18,7 +18,7 @@ export interface GivTcpBatteryStats {
     },
     socEnergy: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         Wh: number,
         kWh: number,
         display: number,
@@ -26,7 +26,7 @@ export interface GivTcpBatteryStats {
     },
     dischargePower: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         w: number,
         kW: number,
         display: number,
@@ -34,7 +34,7 @@ export interface GivTcpBatteryStats {
     },
     chargePower: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         w: number,
         kW: number,
         display: number,
@@ -42,7 +42,7 @@ export interface GivTcpBatteryStats {
     },
     batteryCapacity: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         Wh: number,
         kWh: number,
         display: number,
@@ -50,7 +50,7 @@ export interface GivTcpBatteryStats {
     },
     batteryPowerReservePercent: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         value: number,
         display: number,
         displayStr: string,
@@ -63,7 +63,7 @@ export interface GivTcpBatteryStats {
     },
     chargeRate: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         w: number,
         kW: number,
         display: number,
@@ -71,9 +71,26 @@ export interface GivTcpBatteryStats {
     },
     dischargeRate: {
         rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement form GivTCP
+        uom: string | undefined, // unit_of_measurement from GivTCP
         w: number,
         kW: number,
+        display: number,
+        displayStr: string,
+    },
+    usableBatteryCapacity: {
+        rawState: string, // calculated from custom DoD setting
+        uom: string | undefined, // unit_of_measurement from GivTCP battery_capacity
+        Wh: number,
+        kWh: number,
+        dod: number,
+        display: number,
+        displayStr: string,
+    },
+    calculatedSocEnergy: {
+        rawState: string, // calculated from custom DoD setting
+        uom: string | undefined, // unit_of_measurement from GivTCP unit_of_measurement
+        Wh: number,
+        kWh: number,
         display: number,
         displayStr: string,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,97 +1,25 @@
+export interface GivTcpStats {
+    rawState: string, // store raw value from GivTCP
+    uom: string | undefined, // unit_of_measurement from GivTCP
+    value: number,
+    kValue: number,
+    display: number,
+    displayStr: string,
+    displayUnit: string | undefined,
+}
 
 export interface GivTcpBatteryStats {
-    socPercent: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        value: number,
-        display: number,
-        displayStr: string,
-    },
-    batteryPower: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        w: number,
-        kW: number,
-        display: number,
-        displayStr: string,
-        displayUnit: string,
-    },
-    socEnergy: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        Wh: number,
-        kWh: number,
-        display: number,
-        displayStr: string,
-    },
-    dischargePower: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        w: number,
-        kW: number,
-        display: number,
-        displayStr: string,
-    },
-    chargePower: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        w: number,
-        kW: number,
-        display: number,
-        displayStr: string,
-    },
-    batteryCapacity: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        Wh: number,
-        kWh: number,
-        display: number,
-        displayStr: string,
-    },
-    batteryPowerReservePercent: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        value: number,
-        display: number,
-        displayStr: string,
-    },
-    batteryPowerReserveEnergy: {
-        Wh: number,
-        kWh: number,
-        display: number,
-        displayStr: string,
-    },
-    chargeRate: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        w: number,
-        kW: number,
-        display: number,
-        displayStr: string,
-    },
-    dischargeRate: {
-        rawState: string, // store raw value from GivTCP
-        uom: string | undefined, // unit_of_measurement from GivTCP
-        w: number,
-        kW: number,
-        display: number,
-        displayStr: string,
-    },
-    usableBatteryCapacity: {
-        rawState: string, // calculated from custom DoD setting
-        uom: string | undefined, // unit_of_measurement from GivTCP battery_capacity
-        Wh: number,
-        kWh: number,
-        dod: number,
-        display: number,
-        displayStr: string,
-    },
-    calculatedSocEnergy: {
-        rawState: string, // calculated from custom DoD setting
-        uom: string | undefined, // unit_of_measurement from GivTCP unit_of_measurement
-        Wh: number,
-        kWh: number,
-        display: number,
-        displayStr: string,
-    },
+    socPercent: GivTcpStats,
+    batteryPower: GivTcpStats,
+    socEnergy: GivTcpStats,
+    dischargePower: GivTcpStats,
+    chargePower: GivTcpStats,
+    batteryCapacity: GivTcpStats,
+    batteryPowerReservePercent: GivTcpStats,
+    batteryPowerReserveEnergy: GivTcpStats,
+    chargeRate: GivTcpStats,
+    dischargeRate: GivTcpStats,
+    usableBatteryCapacity: GivTcpStats,
+    calculatedSocEnergy: GivTcpStats,
+    batteryUsageRatePercent: GivTcpStats,
 }


### PR DESCRIPTION
Resolves #20 - adds a new (experimental) feature to configure a custom DoD.

- Add config option to set custom DoD value as a percentage
- Add option to enable/disable custom DoD usage

When set, values for the usable capacity and current SOC kWh will be calculated based on the configured DoD value. These will override and be used in place of the `sensor.INVERTOR_SERIAL_battery_capacity` and `sensor.INVERTOR_SERIAL_soc_kwh` data supplied by GivTCP when displaying battery data in the card.

Several other fixes, improvements and code refactoring.