### PR TITLE
Check misconfiguration & add debug output config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Edit your chosen dashboard and use the "Add Card" button to select the "GivTCP B
 
 ```yaml
 type: custom:givtcp-battery-card
-entity: sensor.givetcp_abc123_invertor_serial_number
+entity: sensor.givtcp_abc123_invertor_serial_number
 name: Battery
 soc_threshold_very_high: 80
 soc_threshold_high: 60

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -19,7 +19,7 @@ import {
     DISPLAY_BATTERY_RATES,
     USE_CUSTOM_DOD,
     CUSTOM_DOD,
-    CALCULATE_RESERVE_FROM_DOD, DISPLAY_CUSTOM_DOD_STATS,
+    CALCULATE_RESERVE_FROM_DOD, DISPLAY_CUSTOM_DOD_STATS, ENABLE_DEBUG_OUTPUT,
 } from "./constants";
 
 export class ConfigUtils {
@@ -47,6 +47,7 @@ export class ConfigUtils {
             custom_dod: CUSTOM_DOD,
             calculate_reserve_from_dod: CALCULATE_RESERVE_FROM_DOD,
             display_custom_dod_stats: DISPLAY_CUSTOM_DOD_STATS,
+            enable_debug_output: ENABLE_DEBUG_OUTPUT,
         };
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,3 +39,5 @@ export const DISPLAY_UNITS = {
     WH: "Wh",
     KWH: "kWh",
 }
+
+export const ENABLE_DEBUG_OUTPUT = false;

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -609,6 +609,19 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
       return html``;
     }
 
+    // first check it's actually in invertor. Checking for the invertor_power entity should suffice
+    // as currently GivTCP only creates this entity for invertors
+    const invertorExists = this._getInvertorPower
+    if(invertorExists === undefined) {
+      return html`
+        <ha-card>
+          <div class="preview">
+            <p>Could not find invertor ${this.config.entity}. Please check your config and ensure you are adding
+            the invertor's serial sensor.</p>
+          </div>
+        </ha-card>`;
+    }
+
     let batteryRateData = html``;
     const displayBatteryRates = (this.config.display_battery_rates !== undefined) ? this.config.display_battery_rates : DISPLAY_BATTERY_RATES;
 
@@ -747,6 +760,10 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
   private get _getBatteryDischargeRate(): HassEntity {
     return this.hass.states[`number.${this._getSensorPrefix}battery_discharge_rate`];
+  }
+
+  private get _getInvertorPower(): HassEntity {
+    return this.hass.states[`sensor.${this._getSensorPrefix}invertor_power`];
   }
 
   private get _getBatteryStatus(): string {

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -341,6 +341,10 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
       displayUnit: "%",
     }
 
+    if(this.config.enable_debug_output === true) {
+      console.log(states);
+    }
+
     this.calculatedStates = states;
   }
 

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -767,7 +767,8 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
   }
 
   private get _getBatteryStatus(): string {
-    const power = parseInt(this._getBatteryPowerEntity.state, 10);
+
+    const power = this.calculatedStates.batteryPower.value;
 
     let status = '';
     if (power > 0) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -22,6 +22,14 @@ export const GENERAL_SCHEMA = (invertorList: string[], defaults: LovelaceCardCon
                 }
             },
         },
+        {
+            name: 'enable_debug_output',
+            label: 'Enable debug output to developer console',
+            default: defaults.enable_debug_output,
+            selector: {
+                boolean: {}
+            }
+        },
     ];
 }
 


### PR DESCRIPTION
Resolves #29 
Resolves #30 

- Simple error check for invertor serial configuration
- Fix typo in README's example `yaml`
- Get battery status from calculated power value
- Add debug output to console & config option