### PR TITLE
fix - check entity status and output message if disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,3 +25,8 @@ export interface GivTcpBatteryStats {
     chargeEnergyToday: GivTcpStats,
     dischargeEnergyToday: GivTcpStats,
 }
+
+export interface GivTcpCheckEntityResult {
+    found: boolean
+    sensor: string
+}


### PR DESCRIPTION
Resolves #40 

Before rendering, the card checks the status of each required entity. If any entity is unavailable (e.g. due to being manually disabled/removed from Home Assistant), a meaningful error will be displayed in the card informing the user of the issue.

This fixes the current issue when the card silently fails and displays a blank card.