### PR TITLE
Feature: Allow configurable trickle charge throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,33 +46,35 @@ Edit your chosen dashboard and use the "Add Card" button to select the "GivTCP B
 
 ## Options
 
-| Name                           | Type         | Requirement  | Description                                                                                                     | Default              |
-|--------------------------------|--------------|--------------|-----------------------------------------------------------------------------------------------------------------|----------------------|
-| type                           | string       | **Required** | `custom:givtcp-battery-card`                                                                                    |                      |
-| entity                         | string       | **Required** | Home Assistant entity ID.                                                                                       | `none`               |
-| name                           | string       | Optional     | Card name                                                                                                       | `Battery`            |
-| soc_threshold_very_high        | number       | Optional     | When SOC is >= this, `soc_threshold_very_high_colour` is used for the icon colour                               | `80`                 |
-| soc_threshold_high             | number       | Optional     | When SOC is >= this, `soc_threshold_high_colour` is used for the icon colour                                    | `60`                 |
-| soc_threshold_medium           | number       | Optional     | When SOC is >= this, `soc_threshold_medium_colour` is used for the icon colour                                  | `40`                 |
-| soc_threshold_low              | number       | Optional     | When SOC is >= this, `soc_threshold_low_colour` is used for the icon colour                                     | `20`                 |
-| soc_colour_input               | string       | Optional     | Input type for the colours. One of `rgb_picker` or `theme_var`                                                  | `rgb_picker`         |
-| soc_threshold_very_high_colour | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_very_high` | `[0, 69, 23]`        |
-| soc_threshold_high_colour      | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_high`      | `[67, 160, 71]`      |
-| soc_threshold_medium_colour    | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_medium`    | `[255, 166, 0]`      |
-| soc_threshold_low_colour       | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_low`       | `[219, 68, 55]`      |
-| soc_threshold_very_low_colour  | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC < `soc_threshold_low`        | `[94, 0, 0]`         |
-| display_abs_power              | boolean      | Optional     | Display the battery power usage as an absolute (unsigned integer) value                                         | `false`              |
-| display_type                   | number       | Optional     | Display type. 0: Wh, 1: kWh, 2: Dynamic                                                                         | `3`                  |
-| display_dp                     | number       | Optional     | Round to decimal places for `display_type` kWh or Dynamic. 1 - 3                                                | `3`                  |
-| icon_status_idle               | string       | Optional     | Icon for Idle battery status                                                                                    | `mdi:sleep`          |
-| icon_status_charging           | string       | Optional     | Icon for Charging battery status                                                                                | `mdi:lightning-bolt` |
-| icon_status_discharging        | string       | Optional     | Icon for Discharging battery status                                                                             | `mdi:home-battery`   |
-| display_battery_rates          | boolean      | Optional     | Display charge/dischare rate as % and graphical bar                                                             | `true`               |
-| use_custom_dod                 | boolean      | Optional     | Use custom DoD % to override GivTCP capacity & SoC values                                                       | `false`              |
-| custom_dod                     | number       | Optional     | Custom DoD value as a percentage. Used when `use_custom_dod` is `true`                                          | `100`                |
-| calculate_reserve_from_dod     | boolean      | Optional     | Use custom DoD value to also calculate the battery reserve value. Note - using this also affects the timers     | `false `             |
-| display_custom_dod_stats       | boolean      | Optional     | Display the derived custom DoD (capacity and reserve) stats                                                     | `true`               |
-| display_energy_today           | boolean      | Optional     | Display statistics for daily charge/discharge                                                                   | `true`               |
+| Name                            | Type         | Requirement  | Description                                                                                                                                          | Default              |
+|---------------------------------|--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| type                            | string       | **Required** | `custom:givtcp-battery-card`                                                                                                                         |                      |
+| entity                          | string       | **Required** | Home Assistant entity ID.                                                                                                                            | `none`               |
+| name                            | string       | Optional     | Card name                                                                                                                                            | `Battery`            |
+| soc_threshold_very_high         | number       | Optional     | When SOC is >= this, `soc_threshold_very_high_colour` is used for the icon colour                                                                    | `80`                 |
+| soc_threshold_high              | number       | Optional     | When SOC is >= this, `soc_threshold_high_colour` is used for the icon colour                                                                         | `60`                 |
+| soc_threshold_medium            | number       | Optional     | When SOC is >= this, `soc_threshold_medium_colour` is used for the icon colour                                                                       | `40`                 |
+| soc_threshold_low               | number       | Optional     | When SOC is >= this, `soc_threshold_low_colour` is used for the icon colour                                                                          | `20`                 |
+| soc_colour_input                | string       | Optional     | Input type for the colours. One of `rgb_picker` or `theme_var`                                                                                       | `rgb_picker`         |
+| soc_threshold_very_high_colour  | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_very_high`                                      | `[0, 69, 23]`        |
+| soc_threshold_high_colour       | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_high`                                           | `[67, 160, 71]`      |
+| soc_threshold_medium_colour     | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_medium`                                         | `[255, 166, 0]`      |
+| soc_threshold_low_colour        | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_low`                                            | `[219, 68, 55]`      |
+| soc_threshold_very_low_colour   | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC < `soc_threshold_low`                                             | `[94, 0, 0]`         |
+| display_abs_power               | boolean      | Optional     | Display the battery power usage as an absolute (unsigned integer) value                                                                              | `false`              |
+| display_type                    | number       | Optional     | Display type. 0: Wh, 1: kWh, 2: Dynamic                                                                                                              | `3`                  |
+| display_dp                      | number       | Optional     | Round to decimal places for `display_type` kWh or Dynamic. 1 - 3                                                                                     | `3`                  |
+| icon_status_idle                | string       | Optional     | Icon for Idle battery status                                                                                                                         | `mdi:sleep`          |
+| icon_status_charging            | string       | Optional     | Icon for Charging battery status                                                                                                                     | `mdi:lightning-bolt` |
+| icon_status_discharging         | string       | Optional     | Icon for Discharging battery status                                                                                                                  | `mdi:home-battery`   |
+| display_battery_rates           | boolean      | Optional     | Display charge/dischare rate as % and graphical bar                                                                                                  | `true`               |
+| use_custom_dod                  | boolean      | Optional     | Use custom DoD % to override GivTCP capacity & SoC values                                                                                            | `false`              |
+| custom_dod                      | number       | Optional     | Custom DoD value as a percentage. Used when `use_custom_dod` is `true`                                                                               | `100`                |
+| calculate_reserve_from_dod      | boolean      | Optional     | Use custom DoD value to also calculate the battery reserve value. Note - using this also affects the timers                                          | `false `             |
+| display_custom_dod_stats        | boolean      | Optional     | Display the derived custom DoD (capacity and reserve) stats                                                                                          | `true`               |
+| display_energy_today            | boolean      | Optional     | Display statistics for daily charge/discharge                                                                                                        | `true`               |
+| trickle_charge_filter           | boolean      | Optional     | Enable/disable trickle charge filter. If actual battery power < filter threshold, charge/discharge power will be displayed as zero and idle          | `false`              |
+| trickle_charge_filter_threshold | number       | Optional     | If trickle charge filter is enabled, and the battery power is less than this value (in W), charge/discharge power will be displayed as zero and idle | `25`                 |                      
 
 ## Raw YAML example
 
@@ -117,6 +119,8 @@ custom_dod: 95
 calculate_reserve_from_dod: true
 display_custom_dod_stats: true
 display_energy_today: true
+trickle_charge_filter: false
+trickle_charge_filter_threshold: 25
 ```
 
 ## YAML example for using Them variable names as colours

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.3.0-beta.3",
+  "version": "0.3.0-beta.4",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -23,6 +23,7 @@ import {
     CALCULATE_RESERVE_FROM_DOD,
     DISPLAY_CUSTOM_DOD_STATS,
     DISPLAY_ENERGY_TODAY,
+    TRICKLE_CHARGE_THROTTLE_THRESHOLD,
 } from "./constants";
 
 export class ConfigUtils {
@@ -53,6 +54,8 @@ export class ConfigUtils {
             display_custom_dod_stats: DISPLAY_CUSTOM_DOD_STATS,
             display_energy_today: DISPLAY_ENERGY_TODAY,
             enable_debug_mode: false,
+            trickle_charge_throttle: false,
+            trickle_charge_throttle_threshold: TRICKLE_CHARGE_THROTTLE_THRESHOLD,
         };
     }
 

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -23,7 +23,7 @@ import {
     CALCULATE_RESERVE_FROM_DOD,
     DISPLAY_CUSTOM_DOD_STATS,
     DISPLAY_ENERGY_TODAY,
-    TRICKLE_CHARGE_THROTTLE_THRESHOLD,
+    TRICKLE_CHARGE_FILTER_THRESHOLD,
 } from "./constants";
 
 export class ConfigUtils {
@@ -54,8 +54,8 @@ export class ConfigUtils {
             display_custom_dod_stats: DISPLAY_CUSTOM_DOD_STATS,
             display_energy_today: DISPLAY_ENERGY_TODAY,
             enable_debug_mode: false,
-            trickle_charge_throttle: false,
-            trickle_charge_throttle_threshold: TRICKLE_CHARGE_THROTTLE_THRESHOLD,
+            trickle_charge_filter: false,
+            trickle_charge_filter_threshold: TRICKLE_CHARGE_FILTER_THRESHOLD,
         };
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,8 @@ export const DISPLAY_UNITS = {
     KWH: "kWh",
 }
 
+export const TRICKLE_CHARGE_THROTTLE_THRESHOLD = 25
+
 export const DISPLAY_ENERGY_TODAY = true;
 
 export const SENSORS_USED: GivTcpEntityMeta[] = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const DISPLAY_UNITS = {
     KWH: "kWh",
 }
 
-export const TRICKLE_CHARGE_THROTTLE_THRESHOLD = 25
+export const TRICKLE_CHARGE_FILTER_THRESHOLD = 25
 
 export const DISPLAY_ENERGY_TODAY = true;
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,7 +2,7 @@ import {fireEvent, HomeAssistant, LovelaceCardConfig, LovelaceCardEditor, Lovela
 import {customElement, property, state} from "lit/decorators.js";
 import {css, CSSResultGroup, html, LitElement, TemplateResult} from "lit";
 import {ConfigUtils} from "./config-utils";
-import {DISPLAY_SCHEMA, DOD_SCHEMA, GENERAL_SCHEMA, SOC_SCHEMA} from "./schemas";
+import {DISPLAY_SCHEMA, DOD_SCHEMA, GENERAL_SCHEMA, SOC_SCHEMA, TRICKLE_CHARGE_SCHEMA} from "./schemas";
 
 @customElement('givtcp-battery-card-editor')
 export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardEditor {
@@ -32,6 +32,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 return DISPLAY_SCHEMA(defaults);
             case 3:
                 return DOD_SCHEMA(defaults, this._config);
+            case 4:
+                return TRICKLE_CHARGE_SCHEMA(defaults, this._config);
         }
     }
 
@@ -62,6 +64,7 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
           <paper-tab>SOC</paper-tab>
           <paper-tab>Display</paper-tab>
           <paper-tab>DOD</paper-tab>
+          <paper-tab>Trickle</paper-tab>
         </ha-tabs>
         <ha-form
           .hass=${this.hass}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -64,7 +64,7 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
           <paper-tab>SOC</paper-tab>
           <paper-tab>Display</paper-tab>
           <paper-tab>DOD</paper-tab>
-          <paper-tab>Trickle</paper-tab>
+          <paper-tab>Filters</paper-tab>
         </ha-tabs>
         <ha-form
           .hass=${this.hass}

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -32,7 +32,10 @@ import {
   CUSTOM_DOD,
   CALCULATE_RESERVE_FROM_DOD,
   DISPLAY_CUSTOM_DOD_STATS,
-  DISPLAY_UNITS, DISPLAY_ENERGY_TODAY, SOC_COLOUR_INPUT_TYPES, SENSORS_USED, TRICKLE_CHARGE_THROTTLE_THRESHOLD,
+  DISPLAY_UNITS, DISPLAY_ENERGY_TODAY,
+  SOC_COLOUR_INPUT_TYPES,
+  SENSORS_USED,
+  TRICKLE_CHARGE_FILTER_THRESHOLD,
 } from "./constants";
 
 import './components/countdown'
@@ -276,12 +279,12 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
   postProcessBatteryPowerStates(states: GivTcpBatteryStats): GivTcpBatteryStats {
 
-    const useTrickleThrottle = (this.config.trickle_charge_throttle !== undefined) ? this.config.trickle_charge_throttle : false;
-    const limit = (this.config.trickle_charge_throttle_threshold !== undefined) ? this.config.trickle_charge_throttle_threshold : TRICKLE_CHARGE_THROTTLE_THRESHOLD;
+    const useTrickleFilter = (this.config.trickle_charge_filter !== undefined) ? this.config.trickle_charge_filter : false;
+    const limit = (this.config.trickle_charge_filter_threshold !== undefined) ? this.config.trickle_charge_filter_threshold : TRICKLE_CHARGE_FILTER_THRESHOLD;
 
-    // if the user has enabled trickle throttle, and current battery power is < the limit, set
+    // if the user has enabled trickle filter, and current battery power is < the limit, set
     // values to zero. However, retain the raw state value for reference/debugging
-    if(useTrickleThrottle === true && Math.abs(states.batteryPower.value) < limit) {
+    if(useTrickleFilter === true && Math.abs(states.batteryPower.value) < limit) {
       states.batteryPower.value = 0
       states.batteryPower.kValue = 0
       states.batteryPower.display = 0
@@ -388,7 +391,7 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
     if(debugEnabled === true) {
       // ToDo - comment out for release. Only uncomment for alpha/beta
-      console.log(this.calculatedStates)
+      // console.log(this.calculatedStates)
     }
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -254,3 +254,38 @@ export const DOD_SCHEMA = (defaults: LovelaceCardConfig, config: LovelaceCardCon
     }
     return settings;
 }
+
+export const TRICKLE_CHARGE_SCHEMA = (defaults: LovelaceCardConfig, config: LovelaceCardConfig) => {
+    let settings: object[] = [
+        HEADING_SCHEMA('Throttle Trickle Charge (if battery charge/discharge power < throttle it will be displayed as zero)'),
+        {
+            name: 'trickle_charge_throttle',
+            label: 'Use Throttle',
+            default: defaults.trickle_charge_throttle,
+            selector: {
+                boolean: {}
+            }
+        },
+    ];
+
+    if (config.trickle_charge_throttle) {
+        settings = [
+            ...settings,
+            {
+                name: 'trickle_charge_throttle_threshold',
+                label: 'Throttle Threshold',
+                default: defaults.trickle_charge_throttle_threshold,
+                selector: {
+                    number: {
+                        min: 0,
+                        max: 50,
+                        step: 1,
+                        unit_of_measurement: "W",
+                    }
+                }
+            },
+        ];
+    }
+
+    return settings;
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -257,24 +257,24 @@ export const DOD_SCHEMA = (defaults: LovelaceCardConfig, config: LovelaceCardCon
 
 export const TRICKLE_CHARGE_SCHEMA = (defaults: LovelaceCardConfig, config: LovelaceCardConfig) => {
     let settings: object[] = [
-        HEADING_SCHEMA('Throttle Trickle Charge (if battery charge/discharge power < throttle it will be displayed as zero)'),
+        HEADING_SCHEMA('Filter out small battery charge/discharge values. If the battery charge/discharge is less than filter threshold, display as zero'),
         {
-            name: 'trickle_charge_throttle',
-            label: 'Use Throttle',
-            default: defaults.trickle_charge_throttle,
+            name: 'trickle_charge_filter',
+            label: 'Use Low Value Filter',
+            default: defaults.trickle_charge_filter,
             selector: {
                 boolean: {}
             }
         },
     ];
 
-    if (config.trickle_charge_throttle) {
+    if (config.trickle_charge_filter) {
         settings = [
             ...settings,
             {
-                name: 'trickle_charge_throttle_threshold',
-                label: 'Throttle Threshold',
-                default: defaults.trickle_charge_throttle_threshold,
+                name: 'trickle_charge_filter_threshold',
+                label: 'Filter Threshold',
+                default: defaults.trickle_charge_filter_threshold,
                 selector: {
                     number: {
                         min: 0,


### PR DESCRIPTION
Adds two configuration values to enable/disable and set a trickle charge throttle value (in W). If enabled, and the battery power/charge/discharge power is less than the throttle limit, then the display values will be zero and the battery status will effectively be "idle".

