### PR TITLE
Feature: enable configurable override values for sensor entity IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,35 +46,47 @@ Edit your chosen dashboard and use the "Add Card" button to select the "GivTCP B
 
 ## Options
 
-| Name                            | Type         | Requirement  | Description                                                                                                                                          | Default              |
-|---------------------------------|--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
-| type                            | string       | **Required** | `custom:givtcp-battery-card`                                                                                                                         |                      |
-| entity                          | string       | **Required** | Home Assistant entity ID.                                                                                                                            | `none`               |
-| name                            | string       | Optional     | Card name                                                                                                                                            | `Battery`            |
-| soc_threshold_very_high         | number       | Optional     | When SOC is >= this, `soc_threshold_very_high_colour` is used for the icon colour                                                                    | `80`                 |
-| soc_threshold_high              | number       | Optional     | When SOC is >= this, `soc_threshold_high_colour` is used for the icon colour                                                                         | `60`                 |
-| soc_threshold_medium            | number       | Optional     | When SOC is >= this, `soc_threshold_medium_colour` is used for the icon colour                                                                       | `40`                 |
-| soc_threshold_low               | number       | Optional     | When SOC is >= this, `soc_threshold_low_colour` is used for the icon colour                                                                          | `20`                 |
-| soc_colour_input                | string       | Optional     | Input type for the colours. One of `rgb_picker` or `theme_var`                                                                                       | `rgb_picker`         |
-| soc_threshold_very_high_colour  | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_very_high`                                      | `[0, 69, 23]`        |
-| soc_threshold_high_colour       | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_high`                                           | `[67, 160, 71]`      |
-| soc_threshold_medium_colour     | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_medium`                                         | `[255, 166, 0]`      |
-| soc_threshold_low_colour        | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_low`                                            | `[219, 68, 55]`      |
-| soc_threshold_very_low_colour   | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC < `soc_threshold_low`                                             | `[94, 0, 0]`         |
-| display_abs_power               | boolean      | Optional     | Display the battery power usage as an absolute (unsigned integer) value                                                                              | `false`              |
-| display_type                    | number       | Optional     | Display type. 0: Wh, 1: kWh, 2: Dynamic                                                                                                              | `3`                  |
-| display_dp                      | number       | Optional     | Round to decimal places for `display_type` kWh or Dynamic. 1 - 3                                                                                     | `3`                  |
-| icon_status_idle                | string       | Optional     | Icon for Idle battery status                                                                                                                         | `mdi:sleep`          |
-| icon_status_charging            | string       | Optional     | Icon for Charging battery status                                                                                                                     | `mdi:lightning-bolt` |
-| icon_status_discharging         | string       | Optional     | Icon for Discharging battery status                                                                                                                  | `mdi:home-battery`   |
-| display_battery_rates           | boolean      | Optional     | Display charge/dischare rate as % and graphical bar                                                                                                  | `true`               |
-| use_custom_dod                  | boolean      | Optional     | Use custom DoD % to override GivTCP capacity & SoC values                                                                                            | `false`              |
-| custom_dod                      | number       | Optional     | Custom DoD value as a percentage. Used when `use_custom_dod` is `true`                                                                               | `100`                |
-| calculate_reserve_from_dod      | boolean      | Optional     | Use custom DoD value to also calculate the battery reserve value. Note - using this also affects the timers                                          | `false `             |
-| display_custom_dod_stats        | boolean      | Optional     | Display the derived custom DoD (capacity and reserve) stats                                                                                          | `true`               |
-| display_energy_today            | boolean      | Optional     | Display statistics for daily charge/discharge                                                                                                        | `true`               |
-| trickle_charge_filter           | boolean      | Optional     | Enable/disable trickle charge filter. If actual battery power < filter threshold, charge/discharge power will be displayed as zero and idle          | `false`              |
-| trickle_charge_filter_threshold | number       | Optional     | If trickle charge filter is enabled, and the battery power is less than this value (in W), charge/discharge power will be displayed as zero and idle | `25`                 |                      
+| Name                                        | Type         | Requirement  | Description                                                                                                                                          | Default              |
+|---------------------------------------------|--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| `type`                                      | string       | **Required** | `custom:givtcp-battery-card`                                                                                                                         |                      |
+| `entity`                                    | string       | **Required** | Home Assistant entity ID.                                                                                                                            | `none`               |
+| `name`                                      | string       | Optional     | Card name                                                                                                                                            | `Battery`            |
+| `soc_threshold_very_high`                   | number       | Optional     | When SOC is >= this, `soc_threshold_very_high_colour` is used for the icon colour                                                                    | `80`                 |
+| `soc_threshold_high`                        | number       | Optional     | When SOC is >= this, `soc_threshold_high_colour` is used for the icon colour                                                                         | `60`                 |
+| `soc_threshold_medium`                      | number       | Optional     | When SOC is >= this, `soc_threshold_medium_colour` is used for the icon colour                                                                       | `40`                 |
+| `soc_threshold_low`                         | number       | Optional     | When SOC is >= this, `soc_threshold_low_colour` is used for the icon colour                                                                          | `20`                 |
+| `soc_colour_input`                          | string       | Optional     | Input type for the colours. One of `rgb_picker` or `theme_var`                                                                                       | `rgb_picker`         |
+| `soc_threshold_very_high_colour`            | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_very_high`                                      | `[0, 69, 23]`        |
+| `soc_threshold_high_colour`                 | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_high`                                           | `[67, 160, 71]`      |
+| `soc_threshold_medium_colour`               | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_medium`                                         | `[255, 166, 0]`      |
+| `soc_threshold_low_colour`                  | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC >= `soc_threshold_low`                                            | `[219, 68, 55]`      |
+| `soc_threshold_very_low_colour`             | array/string | Optional     | RGB value or theme variable name (e.g. `--success-color`) for icon colour when SOC < `soc_threshold_low`                                             | `[94, 0, 0]`         |
+| `display_abs_power`                         | boolean      | Optional     | Display the battery power usage as an absolute (unsigned integer) value                                                                              | `false`              |
+| `display_type`                              | number       | Optional     | Display type. 0: Wh, 1: kWh, 2: Dynamic                                                                                                              | `3`                  |
+| `display_dp`                                | number       | Optional     | Round to decimal places for `display_type` kWh or Dynamic. 1 - 3                                                                                     | `3`                  |
+| `icon_status_idle`                          | string       | Optional     | Icon for Idle battery status                                                                                                                         | `mdi:sleep`          |
+| `icon_status_charging`                      | string       | Optional     | Icon for Charging battery status                                                                                                                     | `mdi:lightning-bolt` |
+| `icon_status_discharging`                   | string       | Optional     | Icon for Discharging battery status                                                                                                                  | `mdi:home-battery`   |
+| `display_battery_rates`                     | boolean      | Optional     | Display charge/dischare rate as % and graphical bar                                                                                                  | `true`               |
+| `use_custom_dod`                            | boolean      | Optional     | Use custom DoD % to override GivTCP capacity & SoC values                                                                                            | `false`              |
+| `custom_dod`                                | number       | Optional     | Custom DoD value as a percentage. Used when `use_custom_dod` is `true`                                                                               | `100`                |
+| `calculate_reserve_from_dod`                | boolean      | Optional     | Use custom DoD value to also calculate the battery reserve value. Note - using this also affects the timers                                          | `false `             |
+| `display_custom_dod_stats`                  | boolean      | Optional     | Display the derived custom DoD (capacity and reserve) stats                                                                                          | `true`               |
+| `display_energy_today`                      | boolean      | Optional     | Display statistics for daily charge/discharge                                                                                                        | `true`               |
+| `trickle_charge_filter`                     | boolean      | Optional     | Enable/disable trickle charge filter. If actual battery power < filter threshold, charge/discharge power will be displayed as zero and idle          | `false`              |
+| `trickle_charge_filter_threshold`           | number       | Optional     | If trickle charge filter is enabled, and the battery power is less than this value (in W), charge/discharge power will be displayed as zero and idle | `25`                 |                      
+| `use_custom_sensors`                        | boolean      | Optional     | Enable to override the automatically derived sensor Entity IDs with user defined Entity IDs                                                          | `false`              |
+| `custom_soc`                                | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_soc` entity ID                                                                                   | `""`                 |
+| `custom_battery_power`                      | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_battery_power` entity ID                                                                         | `""`                 |
+| `custom_soc_kwh`                            | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_soc_kwh` entity ID                                                                               | `""`                 |
+| `custom_discharge_power`                    | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_discharge_power` entity ID                                                                       | `""`                 |
+| `custom_charge_power`                       | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_charge_power` entity ID                                                                          | `""`                 |
+| `custom_battery_capacity_kwh`               | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_battery_capacity_kwh` entity ID                                                                  | `""`                 |
+| `custom_battery_charge_energy_today_kwh`    | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_battery_charge_energy_today_kwh` entity ID                                                       | `""`                 |
+| `custom_battery_discharge_energy_today_kwh` | string       | Optional     | Override the default `sensor.givtcp_INVERTOR_SERIAL_battery_discharge_energy_today_kwh` entity ID                                                    | `""`                 |
+| `custom_battery_power_reserve`              | string       | Optional     | Override the default `number.givtcp_INVERTOR_SERIAL_battery_power_reserve` entity ID                                                                 | `""`                 |
+| `custom_battery_charge_rate`                | string       | Optional     | Override the default `number.givtcp_INVERTOR_SERIAL_battery_charge_rate` entity ID                                                                   | `""`                 |
+| `custom_battery_discharge_rate`             | string       | Optional     | Override the default `number.givtcp_INVERTOR_SERIAL_battery_discharge_rate` entity ID                                                                | `""`                 |
 
 ## Raw YAML example
 
@@ -121,6 +133,18 @@ display_custom_dod_stats: true
 display_energy_today: true
 trickle_charge_filter: false
 trickle_charge_filter_threshold: 25
+use_custom_sensors: false
+custom_soc: "sensor.custom_entity_id_for_soc"
+custom_battery_power: ""
+custom_soc_kwh: "sensor.custom_entity_id_for_soc_kwh"
+custom_discharge_power: ""
+custom_charge_power: ""
+custom_battery_capacity_kwh: ""
+custom_battery_charge_energy_today_kwh: ""
+custom_battery_discharge_energy_today_kwh: ""
+custom_battery_power_reserve: ""
+custom_battery_charge_rate: ""
+custom_battery_discharge_rate: ""
 ```
 
 ## YAML example for using Them variable names as colours
@@ -136,5 +160,19 @@ soc_threshold_very_low_colour: --error-color
 
 ## Multiple Invertors and Batteries
 
-Multiple invertors and batteries are currently not supported in a single card instance. A separate card for each
-invertor is required.
+Multiple invertors and batteries are currently not supported natively in a single card instance. A separate card for each
+invertor is recommended. However, a workaround is possible by creating "Combine the state of multiple sensors" Helpers
+in HA to combine sensor values into a single entity, then point the card configuration to these instead.
+
+For example, a GivEnergy Gateway/AIO system with two batteries will have two separate entities for 
+`givtcp_SERIAL_charge_power`. A Helper entity can be created to combine these into a single entity:
+
+```
+sensor.givtcp_combined_charge_power:
+  sensor.givtcp2_SERIAL_charge_power
+  sensor.givtcp3_SERIAL_charge_powe
+```
+
+The `use_custom_sensors` config option can then be set to `true`, and `custom_charge_power` set to 
+`sensor.givtcp_combined_charge_power`. The card will now use `sensor.givtcp_combined_charge_power` instead of
+the default `sensor.givtcp_INVERTOR_SERIAL_charge_power` to query the data.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.3.0-beta.6",
+  "version": "0.3.0",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.3.0-beta.5",
+  "version": "0.3.0-beta.6",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givtcp-battery-card",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "description": "Lovelace card to display GivTCP battery info",
   "private": true,
   "type": "module",

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -56,6 +56,18 @@ export class ConfigUtils {
             enable_debug_mode: false,
             trickle_charge_filter: false,
             trickle_charge_filter_threshold: TRICKLE_CHARGE_FILTER_THRESHOLD,
+            use_custom_sensors: false,
+            custom_soc: "",
+            custom_battery_power: "",
+            custom_soc_kwh: "",
+            custom_discharge_power: "",
+            custom_charge_power: "",
+            custom_battery_capacity_kwh: "",
+            custom_battery_charge_energy_today_kwh: "",
+            custom_battery_discharge_energy_today_kwh: "",
+            custom_battery_power_reserve: "",
+            custom_battery_charge_rate: "",
+            custom_battery_discharge_rate: "",
         };
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {GivTcpEntityMeta} from "./types";
+import {GivTcpExpectedSensors} from "./types";
 
 export const SOC_THRESH_V_HIGH = 80;
 export const SOC_THRESH_V_HIGH_COLOUR = [0, 69, 23]; //#004517
@@ -53,49 +53,49 @@ export const TRICKLE_CHARGE_FILTER_THRESHOLD = 25
 
 export const DISPLAY_ENERGY_TODAY = true;
 
-export const SENSORS_USED: GivTcpEntityMeta[] = [
-    {
+export const SENSORS_USED: GivTcpExpectedSensors = {
+    soc: {
         name: '_soc',
         type: 'sensor'
     },
-    {
+    battery_power: {
         name: '_battery_power',
         type: 'sensor'
     },
-    {
+    soc_kwh: {
         name: '_soc_kwh',
         type: 'sensor'
     },
-    {
+    discharge_power: {
         name: '_discharge_power',
         type: 'sensor'
     },
-    {
+    charge_power: {
         name: '_charge_power',
         type: 'sensor'
     },
-    {
+    battery_capacity_kwh: {
         name: '_battery_capacity_kwh',
         type: 'sensor'
     },
-    {
+    battery_charge_energy_today_kwh: {
         name: '_battery_charge_energy_today_kwh',
         type: 'sensor'
     },
-    {
+    battery_discharge_energy_today_kwh: {
         name: '_battery_discharge_energy_today_kwh',
         type: 'sensor'
     },
-    {
+    battery_power_reserve: {
         name: '_battery_power_reserve',
         type: 'number'
     },
-    {
+    battery_charge_rate: {
         name: '_battery_charge_rate',
         type: 'number'
     },
-    {
+    battery_discharge_rate: {
         name: '_battery_discharge_rate',
         type: 'number'
     },
-]
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,7 +2,14 @@ import {fireEvent, HomeAssistant, LovelaceCardConfig, LovelaceCardEditor, Lovela
 import {customElement, property, state} from "lit/decorators.js";
 import {css, CSSResultGroup, html, LitElement, TemplateResult} from "lit";
 import {ConfigUtils} from "./config-utils";
-import {DISPLAY_SCHEMA, DOD_SCHEMA, GENERAL_SCHEMA, SOC_SCHEMA, TRICKLE_CHARGE_SCHEMA} from "./schemas";
+import {
+    CUSTOM_SENSOR_SCHEMA,
+    DISPLAY_SCHEMA,
+    DOD_SCHEMA,
+    GENERAL_SCHEMA,
+    SOC_SCHEMA,
+    TRICKLE_CHARGE_SCHEMA
+} from "./schemas";
 
 @customElement('givtcp-battery-card-editor')
 export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardEditor {
@@ -34,6 +41,8 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
                 return DOD_SCHEMA(defaults, this._config);
             case 4:
                 return TRICKLE_CHARGE_SCHEMA(defaults, this._config);
+            case 5:
+                return CUSTOM_SENSOR_SCHEMA(defaults, this._config);
         }
     }
 
@@ -65,6 +74,7 @@ export class GivTCPBatteryCardEditor extends LitElement implements LovelaceCardE
           <paper-tab>Display</paper-tab>
           <paper-tab>DOD</paper-tab>
           <paper-tab>Filters</paper-tab>
+          <paper-tab>Custom</paper-tab> 
         </ha-tabs>
         <ha-form
           .hass=${this.hass}

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -1,22 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  HomeAssistant,
-  LovelaceCardEditor,
-  LovelaceCard,
-  LovelaceCardConfig, fireEvent
-} from 'custom-card-helpers';
-import { LitElement, html, TemplateResult, PropertyValues, CSSResultGroup } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
-import { HassEntity } from 'home-assistant-js-websocket';
+import {fireEvent, HomeAssistant, LovelaceCard, LovelaceCardConfig, LovelaceCardEditor} from 'custom-card-helpers';
+import {CSSResultGroup, html, LitElement, PropertyValues, TemplateResult} from 'lit';
+import {customElement, property, state} from 'lit/decorators.js';
+import {HassEntity} from 'home-assistant-js-websocket';
 
 import {
+  CALCULATE_RESERVE_FROM_DOD,
+  CUSTOM_DOD,
   DISPLAY_ABS_POWER,
+  DISPLAY_BATTERY_RATES,
+  DISPLAY_CUSTOM_DOD_STATS,
   DISPLAY_DP,
+  DISPLAY_ENERGY_TODAY,
   DISPLAY_TYPE,
   DISPLAY_TYPE_OPTIONS,
+  DISPLAY_UNITS,
   ICON_STATUS_CHARGING,
   ICON_STATUS_DISCHARGING,
   ICON_STATUS_IDLE,
+  SENSORS_USED,
+  SOC_COLOUR_INPUT,
+  SOC_COLOUR_INPUT_TYPES,
   SOC_THRESH_HIGH,
   SOC_THRESH_HIGH_COLOUR,
   SOC_THRESH_LOW,
@@ -26,25 +30,22 @@ import {
   SOC_THRESH_V_HIGH,
   SOC_THRESH_V_HIGH_COLOUR,
   SOC_THRESH_V_LOW_COLOUR,
-  SOC_COLOUR_INPUT,
-  DISPLAY_BATTERY_RATES,
-  USE_CUSTOM_DOD,
-  CUSTOM_DOD,
-  CALCULATE_RESERVE_FROM_DOD,
-  DISPLAY_CUSTOM_DOD_STATS,
-  DISPLAY_UNITS, DISPLAY_ENERGY_TODAY,
-  SOC_COLOUR_INPUT_TYPES,
-  SENSORS_USED,
   TRICKLE_CHARGE_FILTER_THRESHOLD,
+  USE_CUSTOM_DOD,
 } from "./constants";
 
 import './components/countdown'
 import './editor';
-import { styleCss } from './style';
+import {styleCss} from './style';
 
-import { version } from '../package.json';
+import {version} from '../package.json';
 import {ConfigUtils} from "./config-utils";
-import {GivSensorPrefixSuffix, GivTcpBatteryStats, GivTcpCheckEntityResult, GivTcpStats} from "./types";
+import {
+  GivSensorPrefixSuffix,
+  GivTcpBatteryStats,
+  GivTcpCheckEntityResult,
+  GivTcpStats
+} from "./types";
 
 // This puts your card into the UI card picker dialog
 (window as any).customCards = (window as any).customCards || [];
@@ -141,8 +142,8 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
       const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
       if (oldHass) {
         let hasChanges = false;
-        for (const e of SENSORS_USED) {
-          const eName = `${e.type}.${this._getSensorPrefix?.prefix}${e.name}${this._getSensorPrefix?.suffix}`
+        for (const [sId, ] of Object.entries(SENSORS_USED)) {
+          const eName = this._getEntityIdOrCustomEntityId(sId)
           if (
             oldHass.states[eName] !== element.hass?.states[eName]
           ) {
@@ -813,66 +814,74 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
     return name.suffix === '' && name.prefix === '' ? undefined : name;
   }
 
-  private _getGivTcpEntity(entType: string, entName: string): HassEntity {
-    const s = `${entType}.${this._getSensorPrefix?.prefix}${entName}${this._getSensorPrefix?.suffix}`
-    return this.hass.states[s];
+  private _generateEntityName(entType: string, entName: string): string {
+    return `${entType}.${this._getSensorPrefix?.prefix}${entName}${this._getSensorPrefix?.suffix}`
+  }
+
+  private _getEntityIdOrCustomEntityId(sensor: string): string {
+    const useCustomEntityId = (this.config.use_custom_sensors !== undefined) ? this.config.use_custom_sensors : false;
+    const customId = `custom_${sensor}`;
+    const customEntityId = (this.config[customId] !== undefined && this.config[customId] !== "") ? this.config[customId] : undefined
+    const autoSensor = (SENSORS_USED as any)[sensor]
+    return (useCustomEntityId && customEntityId !== undefined) ? customEntityId : this._generateEntityName(autoSensor.type, autoSensor.name)
   }
 
   private get _getSocEntity(): HassEntity {
-    return this._getGivTcpEntity('sensor', '_soc')
+    return this.hass.states[this._getEntityIdOrCustomEntityId('soc')]
   }
 
   private get _getBatteryPowerEntity(): HassEntity {
     // can be W or kW
-    return this._getGivTcpEntity('sensor', '_battery_power')
+    return this.hass.states[this._generateEntityName('sensor', '_battery_power')]
   }
 
   private get _getSocKwhEntity(): HassEntity {
     // can be Wh or kWh
-    return this._getGivTcpEntity('sensor', '_soc_kwh')
+    return this.hass.states[this._generateEntityName('sensor', '_soc_kwh')]
   }
 
   private get _getDischargePowerEntity(): HassEntity {
     // can be W or kW
-    return this._getGivTcpEntity('sensor', '_discharge_power')
+    return this.hass.states[this._generateEntityName('sensor', '_discharge_power')]
   }
 
   private get _getChargePowerEntity(): HassEntity {
     // can be W or kW
-    return this._getGivTcpEntity('sensor', '_charge_power')
+    return this.hass.states[this._generateEntityName('sensor', '_charge_power')]
   }
 
   private get _getBatteryCapacityKwhEntity(): HassEntity {
-    return this._getGivTcpEntity('sensor', '_battery_capacity_kwh')
+    return this.hass.states[this._generateEntityName('sensor', '_battery_capacity_kwh')]
   }
 
   private get _getBatteryPowerReserve(): HassEntity {
-    return this._getGivTcpEntity('number', '_battery_power_reserve')
+    return this.hass.states[this._generateEntityName('number', '_battery_power_reserve')]
   }
 
   private get _getBatteryChargeRate(): HassEntity {
-    return this._getGivTcpEntity('number', '_battery_charge_rate')
+    return this.hass.states[this._generateEntityName('number', '_battery_charge_rate')]
   }
 
   private get _getBatteryDischargeRate(): HassEntity {
-    return this._getGivTcpEntity('number', '_battery_discharge_rate')
+    return this.hass.states[this._generateEntityName('number', '_battery_discharge_rate')]
   }
 
   private get _getChargeEnergyTodayEntity(): HassEntity {
-    return this._getGivTcpEntity('sensor', '_battery_charge_energy_today_kwh')
+    return this.hass.states[this._generateEntityName('sensor', '_battery_charge_energy_today_kwh')]
   }
 
   private get _getDischargeEnergyTodayEntity(): HassEntity {
-    return this._getGivTcpEntity('sensor', '_battery_discharge_energy_today_kwh')
+    return this.hass.states[this._generateEntityName('sensor', '_battery_discharge_energy_today_kwh')]
   }
 
-  private _checkSensorAlive(entType: string, entName: string): GivTcpCheckEntityResult {
+  private _checkSensorAlive(sId: string): GivTcpCheckEntityResult {
+    const sensor = this._getEntityIdOrCustomEntityId(sId)
     const r: GivTcpCheckEntityResult = {
-      sensor: `${entType}.${this._getSensorPrefix?.prefix}${entName}${this._getSensorPrefix?.suffix}`,
+      sensor: sensor,
       found: false
     }
     try {
-      const s = this._getGivTcpEntity(entType, entName)
+      const s = this.hass.states[sensor]
       r.found = s !== undefined;
     } catch(e) {
       r.found = false
@@ -884,9 +893,8 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
   private _checkSensorsAvailable(): GivTcpCheckEntityResult[] {
     const results: GivTcpCheckEntityResult[] = []
 
-    for(let i = 0; i < SENSORS_USED.length; i += 1) {
-      const s = SENSORS_USED[i]
-      const r = this._checkSensorAlive(s.type, s.name)
+    for (const [sId, ] of Object.entries(SENSORS_USED)) {
+      const r = this._checkSensorAlive(sId)
       results.push(r)
     }
 

--- a/src/givtcp-battery-card.ts
+++ b/src/givtcp-battery-card.ts
@@ -832,46 +832,46 @@ export class GivTCPBatteryCard extends LitElement implements LovelaceCard {
 
   private get _getBatteryPowerEntity(): HassEntity {
     // can be W or kW
-    return this.hass.states[this._generateEntityName('sensor', '_battery_power')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_power')]
   }
 
   private get _getSocKwhEntity(): HassEntity {
     // can be Wh or kWh
-    return this.hass.states[this._generateEntityName('sensor', '_soc_kwh')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('soc_kwh')]
   }
 
   private get _getDischargePowerEntity(): HassEntity {
     // can be W or kW
-    return this.hass.states[this._generateEntityName('sensor', '_discharge_power')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('discharge_power')]
   }
 
   private get _getChargePowerEntity(): HassEntity {
     // can be W or kW
-    return this.hass.states[this._generateEntityName('sensor', '_charge_power')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('charge_power')]
   }
 
   private get _getBatteryCapacityKwhEntity(): HassEntity {
-    return this.hass.states[this._generateEntityName('sensor', '_battery_capacity_kwh')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_capacity_kwh')]
   }
 
   private get _getBatteryPowerReserve(): HassEntity {
-    return this.hass.states[this._generateEntityName('number', '_battery_power_reserve')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_power_reserve')]
   }
 
   private get _getBatteryChargeRate(): HassEntity {
-    return this.hass.states[this._generateEntityName('number', '_battery_charge_rate')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_charge_rate')]
   }
 
   private get _getBatteryDischargeRate(): HassEntity {
-    return this.hass.states[this._generateEntityName('number', '_battery_discharge_rate')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_discharge_rate')]
   }
 
   private get _getChargeEnergyTodayEntity(): HassEntity {
-    return this.hass.states[this._generateEntityName('sensor', '_battery_charge_energy_today_kwh')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_charge_energy_today_kwh')]
   }
 
   private get _getDischargeEnergyTodayEntity(): HassEntity {
-    return this.hass.states[this._generateEntityName('sensor', '_battery_discharge_energy_today_kwh')]
+    return this.hass.states[this._getEntityIdOrCustomEntityId('battery_discharge_energy_today_kwh')]
   }
 
   private _checkSensorAlive(sId: string): GivTcpCheckEntityResult {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -289,3 +289,113 @@ export const TRICKLE_CHARGE_SCHEMA = (defaults: LovelaceCardConfig, config: Love
 
     return settings;
 }
+
+export const CUSTOM_SENSOR_SCHEMA = (defaults: LovelaceCardConfig, config: LovelaceCardConfig) => {
+    let settings: object[] = [
+        HEADING_SCHEMA('Override automatically detected sensor/entity IDs with custom values'),
+        {
+            name: 'use_custom_sensors',
+            label: 'Use Custom Entity IDs',
+            default: defaults.use_custom_sensors,
+            selector: {
+                boolean: {}
+            }
+        },
+    ];
+
+    if (config.use_custom_sensors) {
+        settings = [
+            ...settings,
+            {
+                name: 'custom_soc',
+                label: 'SOC (e.g. sensor.givtcp_SERIAL_soc)',
+                default: defaults.custom_soc,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_power',
+                label: 'Battery Power (e.g. sensor.givtcp_SERIAL_battery_power)',
+                default: defaults.custom_battery_power,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_soc_kwh',
+                label: 'SOC kWh (e.g. sensor.givtcp_SERIAL_soc_kwh)',
+                default: defaults.custom_soc_kwh,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_discharge_power',
+                label: 'Discharge Power (e.g. sensor.givtcp_SERIAL_discharge_power)',
+                default: defaults.custom_discharge_power,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_charge_power',
+                label: 'Charge Power (e.g. sensor.givtcp_SERIAL_charge_power)',
+                default: defaults.custom_charge_power,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_capacity_kwh',
+                label: 'Capacity kWh (e.g. sensor.givtcp_SERIAL_battery_capacity_kwh)',
+                default: defaults.custom_battery_capacity_kwh,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_charge_energy_today_kwh',
+                label: 'Charge Energy Today (e.g. sensor.givtcp_SERIAL_battery_charge_energy_today_kwh)',
+                default: defaults.custom_battery_charge_energy_today_kwh,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_discharge_energy_today_kwh',
+                label: 'Discharge Energy Today (e.g. sensor.givtcp_SERIAL_battery_discharge_energy_today_kwh)',
+                default: defaults.custom_battery_discharge_energy_today_kwh,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_power_reserve',
+                label: 'Battery Power Reserve (e.g. number.givtcp_SERIAL_battery_power_reserve)',
+                default: defaults.custom_battery_power_reserve,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_charge_rate',
+                label: 'Charge Rate (e.g. number.givtcp_SERIAL_battery_charge_rate)',
+                default: defaults.custom_battery_charge_rate,
+                selector: {
+                    text: {}
+                }
+            },
+            {
+                name: 'custom_battery_discharge_rate',
+                label: 'Discharge Rate (e.g. number.givtcp_SERIAL_battery_discharge_rate)',
+                default: defaults.custom_battery_discharge_rate,
+                selector: {
+                    text: {}
+                }
+            },
+        ];
+    }
+
+    return settings;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,17 @@ export interface GivTcpEntityMeta {
     name: string
     type: string
 }
+
+export interface GivTcpExpectedSensors {
+    soc: GivTcpEntityMeta
+    battery_power: GivTcpEntityMeta
+    soc_kwh: GivTcpEntityMeta
+    discharge_power: GivTcpEntityMeta
+    charge_power: GivTcpEntityMeta
+    battery_capacity_kwh: GivTcpEntityMeta
+    battery_charge_energy_today_kwh: GivTcpEntityMeta
+    battery_discharge_energy_today_kwh: GivTcpEntityMeta
+    battery_power_reserve: GivTcpEntityMeta
+    battery_charge_rate: GivTcpEntityMeta
+    battery_discharge_rate: GivTcpEntityMeta
+}


### PR DESCRIPTION
Adds configuration options to allow users to override the default, automatically derived sensor entity IDs with custom values. This opens the card for use with systems that have modified sensor entity IDs, or even parallel systems with multiple batteries using HA Helpers to combine sensor values.